### PR TITLE
Use caret ranges for dependency version selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,6 @@
     "license": "MIT",
     "repository": "https://github.com/binki/http-autodetect",
     "dependencies": {
-	"node-fastcgi": "~1 >=1.3.0"
+	"node-fastcgi": "^1.3.0"
    }
 }


### PR DESCRIPTION
What you're doing with a complex expression (`~1 >=1.3.0` → major version = 1, minor version >= 3, any patch) can be done with the much simpler [caret range](https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004): `^1.3.0`
